### PR TITLE
Implement offline mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ Overtime I've implemented the following features in this wallet:
 - broadcasting transactions from the node, receiving transactions and updating balance, some reorg safety(especially because reorgs are larger and more frequent on the testnet)
 - non-hardened child key derivation, so basically implementing part of [BIP-32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki)
 - sending to segwit version 0 addresses
+- additional functionality when walet is offline or not fully synchronized, basically an "offline mode"
 
 In-Progress:
-- additional functionality when walet is offline or not fully synchronized, basically an "offline mode"
 - receiving to segwit version 0 addresses
 - make coin selection not SFFO any more, and use effective value when selecting
 - More detailed error messages and more logging

--- a/testnet_bitcoin_wallet/block_logger.py
+++ b/testnet_bitcoin_wallet/block_logger.py
@@ -27,9 +27,17 @@ except (ModuleNotFoundError, ImportError):
 
 logging.basicConfig(filename='block.log', format='%(levelname)s:%(message)s', level=logging.DEBUG)
 
+def initial_connect():
+    try:
+        node = SimpleNode(HOST, testnet=True, logging=False)
+        node.handshake()
+    except (socket.gaierror, ConnectionRefusedError) as e:
+        print(e)
+        print("Please ensure that your wallet and node are both online. If either aren't, consider running the wallet in offline mode temporarily")
+        quit()
+
+
 def block_syncer():
-    node = SimpleNode(HOST, testnet=True, logging=False)
-    node.handshake()
     # As long as wallet is running
     while True:
         now_hash = get_latest_block_hash()

--- a/testnet_bitcoin_wallet/interface.py
+++ b/testnet_bitcoin_wallet/interface.py
@@ -7,7 +7,7 @@ from user_manager import has_login
 from send_to_storage import send_to_storage, get_all_balance
 from stx import get_balance, multi_send
 from rtx import recieve_tx
-from block_logger import block_syncer
+from block_logger import block_syncer, initial_connect
 from block_utils import is_synched, get_known_height, handler, is_valid_node, start_log
 from tx_history import format_tx_history
 
@@ -23,15 +23,26 @@ def run_wallet(p):
         signal.signal(signal.SIGALRM, handler)
         signal.alarm(10)
         try:
+            initial_connect()
             block_syncer()
         except RuntimeError:
             pass
+    online = None
+    while online == None:
+        is_offline = input("Do you want to run this wallet offline? This would mean that you cannot do things like broadcast transactions(though you can still create them) or download utxos.[y/n]")
+        if is_offline == 'y':
+            online = False
+        elif is_offline == 'n':
+            online = True
+
     # ask user to login and obtain their username
     username = has_login()
     print("I can: calculate your current balance[balance], send transactions[send], recieve transactions[recieve], check if your wallet is fully synchronized with the blockchain[status], send all of your testnet bitcoin in all accounts to a specified address[storage], change the full node you get information from[change node], display your full transaction history[tx history] and get your extended public key [tpub] or your extended private key[tprv]")
-    # Start child proccess to run block_syncer()
-    p.start()
-    
+    if online:
+        # Start child proccess to run block_syncer()
+        initial_connect()
+        p.start()
+
     active = True
     # until user enters "quit"
     while active:
@@ -41,7 +52,10 @@ def run_wallet(p):
         # send transaction
         if option == "send":
             # do not allow user to send transactions until the wallet is fullly synchronized
-            if is_synched():
+            if not online:
+                print("Note: your wallet is currently running in 'offline mode', so your transaction won't be broadcasted by this wallet")
+                multi_send(username, online)
+            elif is_synched():
                 multi_send(username)
             else:
                 print("Your wallet is currently in the process of synching with the blockchain. Please try again later.")
@@ -53,7 +67,9 @@ def run_wallet(p):
         # See balance (both confirmed and unconfirmed)
         elif option == "balance":
             # If wallet is not fully synchronized, let them know but still show them their balance so far
-            if is_synched() == False:
+            if not online:
+                print("Please note that your wallet is currently offline so your balance has not been updating.")
+            elif is_synched() == False:
                 print("Please note that your wallet is still in the process of synching with the blockchain.")
             balance = get_balance(username, unconfirmed=True)
             print(f"Your current balance is: {balance[0]} Satoshis")
@@ -79,24 +95,32 @@ def run_wallet(p):
             if get_all_balance() == 0:
                 print("You have 0 testnet bitcoin")
             else:
-                if is_synched():
+                if not online:
+                    print("Note: your wallet is currently running in 'offline mode', so your transaction won't be broadcasted by this wallet")
+                    send_to_storage(online)
+                elif is_synched():
                     send_to_storage()
                 else:
                     print("Your wallet is currently in the process of synching with the blockchain. Please try again later.")
         # checks how far the wallet it synchronized
         elif option == "status":
             # this feature also only works when the wallet is completely synchronized
-            if is_synched():
-                print("The wallet is fully synchronized with the blockchain")
+            if online:
+                if is_synched():
+                    print("The wallet is fully synchronized with the blockchain")
+                else:
+                    print("The wallet is in the process of synchronizing with the blockchain.")
+                print(f"The latest known block height is: {get_known_height()}")
             else:
-                print("The wallet is in the process of synchronizing with the blockchain.")
-            print(f"The latest known block height is: {get_known_height()}")
+                print("You are currently running this wallet in 'offline mode', so it is not connected to a full node")
 
         # show the user their full transaction history
         elif option == "tx history":
-            if is_synched() == False:
+            if not online:
+                print("Please note that your wallet is not synching with the blockchain right now because you are running this wallet in 'offline mode'")
+            elif is_synched() == False:
                 print("Please note that your wallet is still in the process of synching with the blockchain.")
-            format_tx_history(username)
+            format_tx_history(username, online)
         
         # allow user to sign into a different account
         elif option == "sign out":
@@ -104,7 +128,10 @@ def run_wallet(p):
         
         elif option == "quit":
              active = False
-             p.terminate()
+             try:
+                 p.terminate()
+             except AttributeError:
+                pass
 
 if __name__ == '__main__':
     p = Process(target=block_syncer)

--- a/testnet_bitcoin_wallet/send_to_storage.py
+++ b/testnet_bitcoin_wallet/send_to_storage.py
@@ -23,7 +23,7 @@ def get_all_balance():
         balance += get_balance(user)
     return balance
 
-def send_to_storage():
+def send_to_storage(online):
     print("Please provide exactly one address to send the funds to. If you don't care where the testnet Bitcoin goes, enter 'default'")
     target_address = input("Address: ")
     if target_address == "default":
@@ -83,11 +83,18 @@ def send_to_storage():
     print("transaction id")
     print(tx_obj.id())
 
-    node = SimpleNode(HOST, testnet=True, logging=False)
-    node.handshake()
-    node.send(tx_obj)
+    if online:
+        node = SimpleNode(HOST, testnet=True, logging=False)
+        node.handshake()
+        node.send(tx_obj)
+        print('tx sent!')
+        self.broadcast = 'n'
+    else:
+        while self_broadcast != 'n' and self_broadcast != 'y':
+            self_broadcast = input("Did you broadcast this transaction yourself?[y/n]")
 
-    for user in users:
-        with open(f"{user}_utxos.csv", 'w') as utxo_file:
-            w = csv.writer(utxo_file)
+    if online or self_broadcast == 'y':
+        for user in users:
+            with open(f"{user}_utxos.csv", 'w') as utxo_file:
+                w = csv.writer(utxo_file)
 

--- a/testnet_bitcoin_wallet/stx.py
+++ b/testnet_bitcoin_wallet/stx.py
@@ -51,7 +51,7 @@ def get_all_utxos(username):
             output.append(utxo)
     return output 
 
-def multi_send(username):
+def multi_send(username, online=True):
     num_r = input("Number of recipients: ")
     try:
         num_r = int(num_r)
@@ -156,14 +156,21 @@ def multi_send(username):
     print("transaction id")
     print(tx_obj.id())
 
-    node = SimpleNode(HOST, testnet=True, logging=False)
-    node.handshake()
-    node.send(tx_obj)
-    print('tx sent!')
+    self_broadcast = None
+    if online:
+        node = SimpleNode(HOST, testnet=True, logging=False)
+        node.handshake()
+        node.send(tx_obj)
+        print('tx sent!')
+        self_broadcast = 'n'
+    else:
+        while self_broadcast != 'n' and self_broadcast != 'y':
+            self_broadcast = input("Did you broadcast this transaction yourself?[y/n]")
 
-    for utxo in used_utxos:
-        tx_set_flag(username, utxo, '2') 
+    if online or self_broadcast == 'y':
+        for utxo in used_utxos:
+            tx_set_flag(username, utxo, '2') 
     
-    if 'change_address' in locals():
-        change_index = len(tx_obj.tx_outs) - 1 
-        tx_set_new(username, tx_obj.id(), change_index, change_amount, change_address, change_script, "0")
+        if 'change_address' in locals():
+            change_index = len(tx_obj.tx_outs) - 1 
+            tx_set_new(username, tx_obj.id(), change_index, change_amount, change_address, change_script, "0")


### PR DESCRIPTION
Now the user is asked if they want to run the wallet in 'offline
mode'. If they do enable this mode, they can't broadcast
transactions but they can still be constructed and their hex
seralizations are still provided to the user to broadcast from
elsewhere.